### PR TITLE
Bump eksctl

### DIFF
--- a/examples/local/.provisio/profiles/sre/profile.yaml.mustache
+++ b/examples/local/.provisio/profiles/sre/profile.yaml.mustache
@@ -36,7 +36,7 @@ tools:
   kind:
     version: 0.12.0
   eksctl:
-    version: 0.77.0
+    version: 0.122.0
   aws-cli:
     version: 2.7.20
   sops:


### PR DESCRIPTION
Previous version is not able to provision k8s clusters in version 1.22 used by our ck8s configs