### PR TITLE
graalvm version up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,11 @@ jobs:
         uses: styfle/cancel-workflow-action@0.10.0
         with:
           access_token: ${{ github.token }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: 'latest'
+          version: '22.1.0'
           java-version: '17'
-          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: ./mvnw clean package -B -Pnative

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           version: '22.1.0'
           java-version: '17'
+          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: ./mvnw clean package -B -Pnative

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: 'latest'
+          version: '22.1.0'
           java-version: '17'
-          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: ./mvnw clean package -B -DskipTests -Pnative

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           version: '22.1.0'
           java-version: '17'
+          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: ./mvnw clean package -B -DskipTests -Pnative


### PR DESCRIPTION
fix for 
```
The job failed because Quarkus detected an unsupported version of GraalVM: 
"native-image 17.0.12 2024-07-16". Quarkus currently supports GraalVM 22.1.0.
```